### PR TITLE
ptime: Use %g to strip trailing zeroes on float values

### DIFF
--- a/sdp_transform/grammar.py
+++ b/sdp_transform/grammar.py
@@ -145,7 +145,7 @@ grammar = {
             # a=ptime:20
             'name': 'ptime',
             'reg': "^ptime:(\d*(?:\.\d*)*)",
-            'format': lambda o: 'ptime:%d' if isinstance(o, int) else 'ptime:%f'
+            'format': lambda o: 'ptime:%d' if isinstance(o, int) else 'ptime:%g'
         },
         {
             # a=maxptime:60


### PR DESCRIPTION
This allows 0.125ms to be displayed as 0.125 and not 0.125000